### PR TITLE
SectionThread.Replies - Bugfixes

### DIFF
--- a/src/epvpapi/SectionThread.cs
+++ b/src/epvpapi/SectionThread.cs
@@ -298,18 +298,27 @@ namespace epvpapi
 
         /// <summary>
         /// Retrieves a list of all posts in the <c>SectionThread</c>
+        /// The amount of pages to fetch will be retrieved from the PageCount property that is updated each time the Thread is updated
+        /// </summary>
+        /// <param name="session"> Session used for sending the request </param>
+        /// <param name="firstPage"> Index of the first page to fetch </param>
+        /// <returns> List of <c>SectionPost</c>s representing the replies </returns>
+        public List<SectionPost> Replies<TUser>(AuthenticatedSession<TUser> session, uint firstPage = 1) where TUser : User
+        {
+            return Replies(session, PageCount, firstPage);
+        }
+
+        /// <summary>
+        /// Retrieves a list of all posts in the <c>SectionThread</c>
         /// </summary>
         /// <param name="session"> Session used for sending the request </param>
         /// <param name="firstPage"> Index of the first page to fetch </param>
         /// <param name="pageCount"> Amount of pages to get replies from. The higher this count, the more data will be generated and received </param>
         /// <returns> List of <c>SectionPost</c>s representing the replies </returns>
-        public List<SectionPost> Replies<TUser>(AuthenticatedSession<TUser> session, uint pageCount = 1, uint firstPage = 1) where TUser : User
+        public List<SectionPost> Replies<TUser>(AuthenticatedSession<TUser> session, uint pageCount, uint firstPage) where TUser : User
         {
             session.ThrowIfInvalid();
             if(ID == 0) throw new ArgumentException("ID must not be empty");
-
-            // in case the amount of pages to fetch is greater than the available page count, set it to the maximum available count
-            pageCount = (pageCount > PageCount && PageCount != 0) ? PageCount : pageCount;
 
             var retrievedReplies = new List<SectionPost>();
             for (uint i = firstPage; i < (firstPage + pageCount); ++i)

--- a/src/epvpapi/SectionThread.cs
+++ b/src/epvpapi/SectionThread.cs
@@ -59,11 +59,6 @@ namespace epvpapi
         /// </summary>
         public uint PageCount { get; set; }
 
-        /// <summary>
-        /// Amount of posts within all pages
-        /// </summary>
-        public uint PostCount { get; set; }
-
         public SectionThread(Section section)
             : this(0, section)
         { }
@@ -317,7 +312,7 @@ namespace epvpapi
             pageCount = (pageCount > PageCount && PageCount != 0) ? PageCount : pageCount;
 
             var retrievedReplies = new List<SectionPost>();
-            for (uint i = firstPage; i <= (firstPage + pageCount); ++i)
+            for (uint i = firstPage; i < (firstPage + pageCount); ++i)
             {
                 var res = session.Get(GetUrl(i));
                 var htmlDocument = new HtmlDocument();

--- a/src/epvpapi/SectionThread.cs
+++ b/src/epvpapi/SectionThread.cs
@@ -317,7 +317,7 @@ namespace epvpapi
             pageCount = (pageCount > PageCount && PageCount != 0) ? PageCount : pageCount;
 
             var retrievedReplies = new List<SectionPost>();
-            for (uint i = 0; i < pageCount; ++i)
+            for (uint i = firstPage; i <= (firstPage + pageCount); ++i)
             {
                 var res = session.Get(GetUrl(i));
                 var htmlDocument = new HtmlDocument();
@@ -335,7 +335,9 @@ namespace epvpapi
                     retrievedReplies.Add(parsedPost);
                 }
 
-                if (i == 0 && retrievedReplies.Count != 0)
+                // store the starting post and 
+                // remove it after storing since it is no reply
+                if (i == 1 && retrievedReplies.Count != 0)
                 {
                     InitialPost = retrievedReplies.First();
                     retrievedReplies.Remove(retrievedReplies.First());

--- a/src/epvpapi/SectionThread.cs
+++ b/src/epvpapi/SectionThread.cs
@@ -305,7 +305,8 @@ namespace epvpapi
         /// <returns> List of <c>SectionPost</c>s representing the replies </returns>
         public List<SectionPost> Replies<TUser>(AuthenticatedSession<TUser> session, uint firstPage = 1) where TUser : User
         {
-            return Replies(session, PageCount, firstPage);
+            var availablePages = (PageCount - firstPage) + 1;
+            return Replies(session, availablePages, firstPage);
         }
 
         /// <summary>

--- a/test/UnitTests/Tests/SectionThreadTest.cs
+++ b/test/UnitTests/Tests/SectionThreadTest.cs
@@ -15,13 +15,14 @@ namespace UnitTests.Tests
         [TestMethod]
         public void TestReplies()
         {
-            // http://www.elitepvpers.com/forum/main/619408-shoutbox-rules-regeln.html
+            // http://www.elitepvpers.com/forum/main/1329965-de-en-infractions-warnings-things-you-should-know.html
             var testThread = new SectionThread(1329965, Section.Main);
 
             try
             {
                 var replies = testThread.Replies(TestEnvironment.Session);
                 Assert.AreNotEqual(0, replies.Count, "No replies were pulled from the test thread");
+                Assert.AreNotEqual(0, testThread.InitialPost.ID, "The initial post of the test thread was not set");
 
                 foreach (var reply in replies)
                 {

--- a/test/UnitTests/Tests/TheBlackMarketTest.cs
+++ b/test/UnitTests/Tests/TheBlackMarketTest.cs
@@ -18,7 +18,7 @@ namespace UnitTests.Tests
         {
             try
             {
-                var treasures = TestEnvironment.Session.ConnectedProfile.GetTreasures(targetStatus, 1, 1);
+                var treasures = TestEnvironment.Session.Profile.GetTreasures(TestEnvironment.Session, targetStatus, 1, 1);
                 if (treasures.Count == 0)
                     Assert.Fail("No treasures were retrieved");
 

--- a/test/UnitTests/Tests/UploadTest.cs
+++ b/test/UnitTests/Tests/UploadTest.cs
@@ -22,17 +22,17 @@ namespace UnitTests.Tests
 
                 if (!String.IsNullOrEmpty(TestEnvironment.Session.User.AvatarUrl))
                 {
-                    TestEnvironment.Session.ConnectedProfile.RemoveAvatar();
+                    TestEnvironment.Session.Profile.RemoveAvatar(TestEnvironment.Session);
                     TestEnvironment.Session.User.Update(TestEnvironment.Session);
 
                     Assert.AreEqual(0, TestEnvironment.Session.User.AvatarUrl.Length, "The avatar of the logged-in user was not removed");
                 }
 
-                TestEnvironment.Session.ConnectedProfile.SetAvatar(schmittAvatar);
+                TestEnvironment.Session.Profile.SetAvatar(TestEnvironment.Session, schmittAvatar);
                 TestEnvironment.Session.User.Update(TestEnvironment.Session);
                 Assert.AreNotEqual(0, TestEnvironment.Session.User.AvatarUrl.Length, "The test avatar from the web was not uploaded and set");
 
-                TestEnvironment.Session.ConnectedProfile.SetAvatar(gitAvatar);
+                TestEnvironment.Session.Profile.SetAvatar(TestEnvironment.Session, gitAvatar);
                 TestEnvironment.Session.User.Update(TestEnvironment.Session);
                 Assert.AreNotEqual(0, TestEnvironment.Session.User.AvatarUrl, "The test avatar from the file system was not uploaded and set");
             }


### PR DESCRIPTION
Fixes some bugs in the `SectionThread.Replies` method that mainly caused wrong output and added an additional method overload for handy usage.